### PR TITLE
Fix phone number tel: link

### DIFF
--- a/resources/views/template.twig
+++ b/resources/views/template.twig
@@ -172,7 +172,7 @@
         </span>
         <span class="contact">
             <a href="mailto:codeday@srnd.org">codeday@srnd.org</a><br />
-            <a href="tel:1882633230">(888) CODE-230</a><br />
+            <a href="tel:18882633230">(888) CODE-230</a><br />
             <a href="https://www.srnd.org/privacy" target="_blank">Privacy &amp; Cookies</a><br />
             <a href="https://www.srnd.org/privacy/controls" target="_blank">Do Not Sell My Personal Information</a>
         </span>


### PR DESCRIPTION
For some reason, I don't have perms for this repo? Anyway, I saw the tel link at the bottom of the website didn't correspond to what the text for the link said. It's been fixed.

Was 1-88-263-3230, missing an 8. 
Now is: 1-88**8**-263-3230

